### PR TITLE
Fix mibdio.c build with clang 10

### DIFF
--- a/mibdio.c
+++ b/mibdio.c
@@ -172,7 +172,7 @@ update_dio_data(void *arg __unused)
 		if (diop->_busy_time.sec > 0) {
 			busy_time = dev.busy_time.sec - diop->_busy_time.sec +
 			    (double)(dev.busy_time.frac - diop->_busy_time.frac)
-			    / 0xffffffffffffffffull;
+			    / (double)0xffffffffffffffffull;
 			if (busy_time < 0) /* FP loss of precision near zero. */
 				busy_time = 0;
 			percent = busy_time * 100 / interval;


### PR DESCRIPTION
clang 10 complains to build with this error message:
mibdio.c:175:10: error: implicit conversion from 'unsigned long long' to 'double' changes value from 18446744073709551615 to 18446744073709551616 [-Werror,-Wimplicit-int-float-conversion]
So convert the ULL into double to silence this error.