### PR TITLE
Copyrights and cleanup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,199 @@
+# Basic .clang-format
+---
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveMacros: AcrossEmptyLines
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: TopLevelDefinitions
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: WebKit
+BreakBeforeTernaryOperators: false
+# TODO: BreakStringLiterals can cause very strange formatting so turn it off?
+BreakStringLiterals: false
+# Prefer:
+# some_var = function(arg1,
+#    arg2)
+# over:
+# some_var =
+#     function(arg1, arg2)
+PenaltyBreakAssignment: 100
+# Prefer:
+# some_long_function(arg1, arg2
+#     arg3)
+# over:
+# some_long_function(
+#     arg1, arg2, arg3)
+PenaltyBreakBeforeFirstCallParameter: 100
+CompactNamespaces: true
+DerivePointerAlignment: false
+DisableFormat: false
+ForEachMacros:
+  - ARB_ARRFOREACH
+  - ARB_ARRFOREACH_REVWCOND
+  - ARB_ARRFOREACH_REVERSE
+  - ARB_FOREACH
+  - ARB_FOREACH_FROM
+  - ARB_FOREACH_SAFE
+  - ARB_FOREACH_REVERSE
+  - ARB_FOREACH_REVERSE_FROM
+  - ARB_FOREACH_REVERSE_SAFE
+  - BIT_FOREACH_ISCLR
+  - BIT_FOREACH_ISSET
+  - CPU_FOREACH
+  - CPU_FOREACH_ISCLR
+  - CPU_FOREACH_ISSET
+  - FOREACH_THREAD_IN_PROC
+  - FOREACH_PROC_IN_SYSTEM
+  - FOREACH_PRISON_CHILD
+  - FOREACH_PRISON_DESCENDANT
+  - FOREACH_PRISON_DESCENDANT_LOCKED
+  - FOREACH_PRISON_DESCENDANT_LOCKED_LEVEL
+  - MNT_VNODE_FOREACH_ALL
+  - MNT_VNODE_FOREACH_ACTIVE
+  - RB_FOREACH
+  - RB_FOREACH_FROM
+  - RB_FOREACH_SAFE
+  - RB_FOREACH_REVERSE
+  - RB_FOREACH_REVERSE_FROM
+  - RB_FOREACH_REVERSE_SAFE
+  - SLIST_FOREACH
+  - SLIST_FOREACH_FROM
+  - SLIST_FOREACH_FROM_SAFE
+  - SLIST_FOREACH_SAFE
+  - SLIST_FOREACH_PREVPTR
+  - SPLAY_FOREACH
+  - LIST_FOREACH
+  - LIST_FOREACH_FROM
+  - LIST_FOREACH_FROM_SAFE
+  - LIST_FOREACH_SAFE
+  - STAILQ_FOREACH
+  - STAILQ_FOREACH_FROM
+  - STAILQ_FOREACH_FROM_SAFE
+  - STAILQ_FOREACH_SAFE
+  - TAILQ_FOREACH
+  - TAILQ_FOREACH_FROM
+  - TAILQ_FOREACH_FROM_SAFE
+  - TAILQ_FOREACH_REVERSE
+  - TAILQ_FOREACH_REVERSE_FROM
+  - TAILQ_FOREACH_REVERSE_FROM_SAFE
+  - TAILQ_FOREACH_REVERSE_SAFE
+  - TAILQ_FOREACH_SAFE
+  - VM_MAP_ENTRY_FOREACH
+  - VM_PAGE_DUMP_FOREACH
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
+IndentCaseLabels: false
+IndentPPDirectives: None
+Language: Cpp
+NamespaceIndentation: None
+PointerAlignment: Right
+ContinuationIndentWidth: 4
+IndentWidth: 8
+TabWidth: 8
+ColumnLimit: 80
+UseTab: Always
+SpaceAfterCStyleCast: false
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^\"opt_.*\.h\"'
+    Priority: 1
+    SortPriority: 10
+  - Regex: '^<sys/cdefs\.h>'
+    Priority: 2
+    SortPriority: 20
+  - Regex: '^<sys/types\.h>'
+    Priority: 2
+    SortPriority: 21
+  - Regex: '^<sys/param\.h>'
+    Priority: 2
+    SortPriority: 22
+  - Regex: '^<sys/systm\.h>'
+    Priority: 2
+    SortPriority: 23
+  - Regex: '^<sys.*/'
+    Priority: 2
+    SortPriority: 24
+  - Regex: '^<vm/vm\.h>'
+    Priority: 3
+    SortPriority: 30
+  - Regex: '^<vm/'
+    Priority: 3
+    SortPriority: 31
+  - Regex: '^<machine/'
+    Priority: 4
+    SortPriority: 40
+  - Regex: '^<(x86|amd64|i386|xen)/'
+    Priority: 5
+    SortPriority: 50
+  - Regex: '^<dev/'
+    Priority: 6
+    SortPriority: 60
+  - Regex: '^<net.*/'
+    Priority: 7
+    SortPriority: 70
+  - Regex: '^<protocols/'
+    Priority: 7
+    SortPriority: 71
+  - Regex: '^<(fs|nfs(|client|server)|ufs)/'
+    Priority: 8
+    SortPriority: 80
+  - Regex: '^<[^/].*'
+    Priority: 9
+    SortPriority: 90
+  - Regex: '^\".*\"'
+    Priority: 10
+    SortPriority: 100
+# LLVM's header include ordering style is almost the exact opposite of ours.
+# Unfortunately, they have hard-coded their preferences into clang-format.
+# Clobbering this regular expression to avoid matching prevents non-system
+# headers from being forcibly moved to the top of the include list.
+# http://llvm.org/docs/CodingStandards.html#include-style
+IncludeIsMainRegex: 'BLAH_DONT_MATCH_ANYTHING'
+SortIncludes: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+TypenameMacros:
+  - ARB_ELMTYPE
+  - ARB_HEAD
+  - ARB8_HEAD
+  - ARB16_HEAD
+  - ARB32_HEAD
+  - ARB_ENTRY
+  - ARB8_ENTRY
+  - ARB16_ENTRY
+  - ARB32_ENTRY
+  - LIST_CLASS_ENTRY
+  - LIST_CLASS_HEAD
+  - LIST_ENTRY
+  - LIST_HEAD
+  - QUEUE_TYPEOF
+  - RB_ENTRY
+  - RB_HEAD
+  - SLIST_CLASS_HEAD
+  - SLIST_CLASS_ENTRY
+  - SLIST_HEAD
+  - SLIST_ENTRY
+  - SMR_POINTER
+  - SPLAY_ENTRY
+  - SPLAY_HEAD
+  - STAILQ_CLASS_ENTRY
+  - STAILQ_CLASS_HEAD
+  - STAILQ_ENTRY
+  - STAILQ_HEAD
+  - TAILQ_CLASS_ENTRY
+  - TAILQ_CLASS_HEAD
+  - TAILQ_ENTRY
+  - TAILQ_HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*.depend*
+*.o
+*.pico
+*.pieo
+snmp_ucd.so*
+*.[0-9].gz
+
+ucd_oid.h
+ucd_tree.c
+ucd_tree.h

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+---
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v6.0.0
+      hooks:
+          - id: check-yaml
+          - id: end-of-file-fixer
+          - id: trailing-whitespace
+    # NOTE: This solution was chosen over https://github.com/pre-commit/mirrors-clang-format
+    # as that version relies on clang-format project python wheels to function, which are not
+    # produced for FreeBSD.
+    #
+    # A copy of `clang-format`, et al, can be easily installed via
+    # `pkg install include-what-you-use llvm21`, etc.
+    - repo: https://github.com/pocc/pre-commit-hooks
+      rev: v1.3.5
+      hooks:
+          - id: clang-format
+          # NOTE: `clang-tidy` and `include-what-you-use` don't work with
+          # `.OBJDIR` out of the box due to `bsd.snmpmod.mk` generated files.
+          - id: clang-tidy
+          - id: include-what-you-use

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,23 @@
+Copyright (c) 2007-2026 Mikolaj Golub
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Copyright (c) 2007-2013 Mikolaj Golub
 # All rights reserved.
 #
-# $Id$
+# SPDX-License-Identifier: BSD-2-Clause
 
 PREFIX?=	/usr/local
 LIBDIR=		${PREFIX}/lib

--- a/UCD-SNMP-MIB.txt
+++ b/UCD-SNMP-MIB.txt
@@ -4,7 +4,7 @@ UCD-SNMP-MIB DEFINITIONS ::= BEGIN
 --
 -- The design of this mib may seem unusual in parts, as it was
 -- designed for ease of numerical management routines.
--- 
+--
 -- In that light, most sub-sections of this mib have four common
 -- numerical oid consistencies:
 --
@@ -39,7 +39,7 @@ IMPORTS
 ucdavis MODULE-IDENTITY
     LAST-UPDATED "200611220000Z"
     ORGANIZATION "University of California, Davis"
-    CONTACT-INFO    
+    CONTACT-INFO
 	"This mib is no longer being maintained by the University of
 	 California and is now in life-support-mode and being
 	 maintained by the net-snmp project.  The best place to write
@@ -110,7 +110,7 @@ ucdExperimental       OBJECT IDENTIFIER ::= { ucdavis 13 }
 
 
 -- These are the returned values of the agent type.
--- returned to:  .iso.org.dod.internet.mgmt.mib-2.system.sysObjectID.0 
+-- returned to:  .iso.org.dod.internet.mgmt.mib-2.system.sysObjectID.0
 
 ucdSnmpAgent      OBJECT IDENTIFIER ::= { ucdavis 250 }
 hpux9             OBJECT IDENTIFIER ::= { ucdSnmpAgent 1 }
@@ -288,7 +288,7 @@ prErrFixCmd OBJECT-TYPE
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
-	"The command that gets run when the prErrFix column is 
+	"The command that gets run when the prErrFix column is
 	 set to 1."
     ::= { prEntry 103 }
 
@@ -374,13 +374,13 @@ extErrFix OBJECT-TYPE
 	 to attempt to fix problems automatically using remote
 	 snmp operations."
     ::= { extEntry 102 }
-	
+
 extErrFixCmd OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
     DESCRIPTION
-	"The command that gets run when the extErrFix column is 
+	"The command that gets run when the extErrFix column is
 	 set to 1."
     ::= { extEntry 103 }
 
@@ -395,17 +395,17 @@ memIndex OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Bogus Index.  This should always return the integer 0."
-    ::= { memory 1 } 
+    ::= { memory 1 }
 
 memErrorName OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Bogus Name. This should always return the string 'swap'."
-    ::= { memory 2 } 
+    ::= { memory 2 }
 
 memTotalSwap OBJECT-TYPE
     SYNTAX	Integer32
@@ -464,7 +464,7 @@ memAvailSwapTXT OBJECT-TYPE
     UNITS       "kB"
     MAX-ACCESS	read-only
     STATUS	deprecated
-    DESCRIPTION	
+    DESCRIPTION
 	"The amount of swap space or virtual memory currently
          being used by text pages on this host.
 
@@ -584,7 +584,7 @@ memUsedSwapTXT OBJECT-TYPE
     UNITS       "kB"
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION	
+    DESCRIPTION
 	"The amount of swap space or virtual memory currently
          being used by text pages on this host.
 
@@ -616,7 +616,7 @@ memSwapError OBJECT-TYPE
          (as reported by 'memAvailSwap(4)'), is less than the
          desired minimum (specified by 'memMinimumSwap(12)')."
     ::= { memory 100 }
-	
+
 memSwapErrorMsg OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
@@ -625,7 +625,7 @@ memSwapErrorMsg OBJECT-TYPE
 	"Describes whether the amount of available swap space
          (as reported by 'memAvailSwap(4)'), is less than the
          desired minimum (specified by 'memMinimumSwap(12)')."
-    ::= { memory 101 } 
+    ::= { memory 101 }
 
 
 dskTable OBJECT-TYPE
@@ -674,88 +674,88 @@ dskIndex OBJECT-TYPE
     DESCRIPTION
 	"Integer reference number (row number) for the disk mib."
     ::= { dskEntry 1 }
-	
+
 dskPath OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Path where the disk is mounted."
-    ::= { dskEntry 2 } 
+    ::= { dskEntry 2 }
 
 dskDevice OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Path of the device for the partition"
-    ::= { dskEntry 3 } 
+    ::= { dskEntry 3 }
 
 dskMinimum OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Minimum space required on the disk (in kBytes) before the
          errors are triggered.  Either this or dskMinPercent is
          configured via the agent's snmpd.conf file."
-    ::= { dskEntry 4 } 
+    ::= { dskEntry 4 }
 
 dskMinPercent OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Percentage of minimum space required on the disk before the
          errors are triggered.  Either this or dskMinimum is
          configured via the agent's snmpd.conf file."
-    ::= { dskEntry 5 } 
+    ::= { dskEntry 5 }
 
 dskTotal OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Total size of the disk/partion (kBytes)"
-    ::= { dskEntry 6 } 
+    ::= { dskEntry 6 }
 
 dskAvail OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Available space on the disk"
-    ::= { dskEntry 7 } 
+    ::= { dskEntry 7 }
 
 dskUsed OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Used space on the disk"
-    ::= { dskEntry 8 } 
+    ::= { dskEntry 8 }
 
 dskPercent OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Percentage of space used on disk"
-    ::= { dskEntry 9 } 
+    ::= { dskEntry 9 }
 
 dskPercentNode OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Percentage of inodes used on disk"
-    ::= { dskEntry 10 } 
+    ::= { dskEntry 10 }
 
 dskTotalLow OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Total size of the disk/partion (kBytes).
 	Together with dskTotalHigh composes 64-bit number."
     ::= { dskEntry 11 }
@@ -764,7 +764,7 @@ dskTotalHigh OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Total size of the disk/partion (kBytes).
 	Together with dskTotalLow composes 64-bit number."
     ::= { dskEntry 12 }
@@ -773,7 +773,7 @@ dskAvailLow OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Available space on the disk (kBytes).
 	Together with dskAvailHigh composes 64-bit number."
     ::= { dskEntry 13 }
@@ -782,7 +782,7 @@ dskAvailHigh OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Available space on the disk (kBytes).
 	Together with dskAvailLow composes 64-bit number."
     ::= { dskEntry 14 }
@@ -791,7 +791,7 @@ dskUsedLow OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Used space on the disk (kBytes).
 	Together with dskUsedHigh composes 64-bit number."
     ::= { dskEntry 15 }
@@ -800,7 +800,7 @@ dskUsedHigh OBJECT-TYPE
     SYNTAX	Unsigned32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Used space on the disk (kBytes).
 	Together with dskUsedLow composes 64-bit number."
     ::= { dskEntry 16 }
@@ -809,20 +809,20 @@ dskErrorFlag OBJECT-TYPE
     SYNTAX	UCDErrorFlag
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Error flag signaling that the disk or partition is under
 	 the minimum required space configured for it."
-    ::= { dskEntry 100 } 
-     
+    ::= { dskEntry 100 }
+
 dskErrorMsg OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"A text description providing a warning and the space left
 	 on the disk."
-    ::= { dskEntry 101 } 
-     
+    ::= { dskEntry 101 }
+
 laTable OBJECT-TYPE
     SYNTAX	SEQUENCE OF LaEntry
     MAX-ACCESS	not-accessible
@@ -931,90 +931,90 @@ versionIndex OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Index to mib (always 0)"
-    ::= { version 1 } 
+    ::= { version 1 }
 
 versionTag OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"CVS tag keyword"
-    ::= { version 2 } 
-     
+    ::= { version 2 }
+
 versionDate OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Date string from RCS keyword"
-    ::= { version 3 } 
+    ::= { version 3 }
 
 versionCDate OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Date string from ctime() "
-    ::= { version 4 } 
+    ::= { version 4 }
 
 versionIdent OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Id string from RCS keyword"
-    ::= { version 5 } 
+    ::= { version 5 }
 
 versionConfigureOptions OBJECT-TYPE
     SYNTAX	DisplayString
     MAX-ACCESS	read-only
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Options passed to the configure script when this agent was built."
-    ::= { version 6 } 
+    ::= { version 6 }
 
 versionClearCache OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-write
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Set to 1 to clear the exec cache, if enabled"
-    ::= { version 10 } 
+    ::= { version 10 }
 
 versionUpdateConfig OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-write
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Set to 1 to read-read the config file(s)."
-    ::= { version 11 } 
+    ::= { version 11 }
 
 versionRestartAgent OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-write
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Set to 1 to restart the agent."
-    ::= { version 12 } 
+    ::= { version 12 }
 
 versionSavePersistentData OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-write
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Set to 1 to force the agent to save it's persistent data immediately."
-    ::= { version 13 } 
+    ::= { version 13 }
 
 versionDoDebugging OBJECT-TYPE
     SYNTAX	Integer32
     MAX-ACCESS	read-write
     STATUS	current
-    DESCRIPTION  
+    DESCRIPTION
 	"Set to 1 to turn debugging statements on in the agent or 0
 	 to turn it off."
-    ::= { version 20 } 
+    ::= { version 20 }
 
 
 snmperrs OBJECT IDENTIFIER ::= { ucdavis 101 }
@@ -1139,7 +1139,7 @@ ssIOSent OBJECT-TYPE
     DESCRIPTION
 	"The average amount of data written to disk or other
          block device, calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssIORawSent(57)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1153,7 +1153,7 @@ ssIOReceive OBJECT-TYPE
     DESCRIPTION
 	"The average amount of data read from disk or other
          block device, calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssIORawReceived(58)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1167,7 +1167,7 @@ ssSysInterrupts OBJECT-TYPE
     DESCRIPTION
 	"The average rate of interrupts processed (including
          the clock) calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssRawInterrupts(59)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1181,7 +1181,7 @@ ssSysContext OBJECT-TYPE
     DESCRIPTION
 	"The average rate of context switches,
          calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssRawContext(60)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1194,7 +1194,7 @@ ssCpuUser OBJECT-TYPE
     DESCRIPTION
 	"The percentage of CPU time spent processing
          user-level code, calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssCpuRawUser(50)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1207,7 +1207,7 @@ ssCpuSystem OBJECT-TYPE
     DESCRIPTION
 	"The percentage of CPU time spent processing
          system-level code, calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssCpuRawSystem(52)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1220,7 +1220,7 @@ ssCpuIdle OBJECT-TYPE
     DESCRIPTION
 	"The percentage of processor time spent idle,
          calculated over the last minute.
-       
+
 	 This object has been deprecated in favour of
          'ssCpuRawIdle(53)', which can be used to calculate
          the same metric, but over any desired time period."
@@ -1417,14 +1417,14 @@ ssRawSwapOut OBJECT-TYPE
 --     DESCRIPTION
 --         "Error flag."
 --     ::= { systemStats 100 }
--- 
+--
 -- ssErrMessage OBJECT-TYPE
 --     SYNTAX      DisplayString
 --     MAX-ACCESS  read-only
 --     STATUS      current
---     DESCRIPTION  
+--     DESCRIPTION
 --         "Error message describing the errorflag condition."
---     ::= { systemStats 101 } 
+--     ::= { systemStats 101 }
 
 
 ucdTraps OBJECT IDENTIFIER ::= { ucdavis 251 }
@@ -1434,7 +1434,7 @@ ucdStart NOTIFICATION-TYPE
     DESCRIPTION
 	"This trap could in principle be sent when the agent start"
     ::= { ucdTraps 1 }
-    
+
 ucdShutdown	NOTIFICATION-TYPE
     STATUS current
     DESCRIPTION
@@ -1443,7 +1443,7 @@ ucdShutdown	NOTIFICATION-TYPE
 
 --
 -- File Table:  monitor a list of files to check for a maximum size.
--- 
+--
 
 fileTable OBJECT-TYPE
     SYNTAX	SEQUENCE OF FileEntry
@@ -1452,7 +1452,7 @@ fileTable OBJECT-TYPE
     DESCRIPTION
 	"Table of monitored files."
     ::= { ucdavis 15 }
-    
+
 fileEntry OBJECT-TYPE
     SYNTAX	FileEntry
     MAX-ACCESS	not-accessible
@@ -1550,7 +1550,7 @@ logMatchEntry OBJECT-TYPE
 	::= { logMatchTable 1 }
 
 LogMatchEntry ::=
-	SEQUENCE { 
+	SEQUENCE {
 		logMatchIndex
 			Integer32,
 		logMatchName

--- a/bsnmp-ucd.8
+++ b/bsnmp-ucd.8
@@ -1,7 +1,7 @@
 .\"
 .\" Copyright (c) 2007 Mikolaj Golub
 .\"	All rights reserved.
-.\" 
+.\"
 .\" Redistribution and use in source and binary forms, with or without
 .\" modification, are permitted provided that the following conditions
 .\" are met:
@@ -10,7 +10,7 @@
 .\" 2. Redistributions in binary form must reproduce the above copyright
 .\"    notice, this list of conditions and the following disclaimer in the
 .\"    documentation and/or other materials provided with the distribution.
-.\" 
+.\"
 .\" THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
 .\" ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 .\" IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -33,7 +33,7 @@
 .Nd an SNMP module which implements parts of UCD-SNMP-MIB.
 .Sh DESCRIPTION
 .Nm
-is a module for 
+is a module for
 .Xr bsnmpd 1
 which allows to get memory, load average, cpu usage and other system
 statistics. It implements parts of UCD-SNMP-MIB for this.
@@ -52,7 +52,7 @@ The counters will be available under the following MIB:
 .Bd -literal -offset indent
  .1.3.6.1.4.1.2021
 .Ed
-.Pp 
+.Pp
 Or if the appropriate MIB file has been installed:
 .Bd -literal -offset indent
 UCD-SNMP-MIB::ucdavis
@@ -141,6 +141,6 @@ configuration file, in
 module section, or at run time, setting the corresponding mibs under
 UCD-SNMP-MIB::ucdavis.1.
 .Sh SEE ALSO
-.Xr bsnmpd 1 
+.Xr bsnmpd 1
 .Sh AUTHOR
 .An Mikolaj Golub

--- a/bsnmp-ucd.8
+++ b/bsnmp-ucd.8
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.\" $Id$
+.\" SPDX-License-Identifier: BSD-2-Clause
 .\"
 .Dd October 11, 2013
 .Dt bsnmp-ucd 8

--- a/mibconfig.c
+++ b/mibconfig.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <unistd.h>

--- a/mibdio.c
+++ b/mibdio.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/param.h>

--- a/mibdisk.c
+++ b/mibdisk.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/param.h>

--- a/mibext.c
+++ b/mibext.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>

--- a/mibla.c
+++ b/mibla.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>

--- a/mibmem.c
+++ b/mibmem.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>

--- a/mibpr.c
+++ b/mibpr.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/param.h>

--- a/mibss.c
+++ b/mibss.c
@@ -388,4 +388,3 @@ op_systemStats(struct snmp_context *context __unused, struct snmp_value *value,
 
 	return (ret);
 };
-

--- a/mibss.c
+++ b/mibss.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>

--- a/mibversion.c
+++ b/mibversion.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 /*

--- a/snmp_ucd.c
+++ b/snmp_ucd.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>

--- a/snmp_ucd.h
+++ b/snmp_ucd.h
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #ifndef SNMP_UCD_H

--- a/snmpd.config.sample
+++ b/snmpd.config.sample
@@ -1,5 +1,3 @@
-# $Id$
-#
 # Example configuration file for bsnmpd(1).
 #
 # Only part related to bsnmp-ucd is shown.

--- a/snmpd.config.sample
+++ b/snmpd.config.sample
@@ -2,7 +2,7 @@
 #
 # Only part related to bsnmp-ucd is shown.
 
-# 
+#
 # bsnmp-ucd (8)
 #
 begemotSnmpdModulePath."ucd" = "/usr/local/lib/snmp_ucd.so"

--- a/utils.c
+++ b/utils.c
@@ -23,8 +23,7 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * $Id$
- *
+ * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <sys/types.h>


### PR DESCRIPTION
This change does the following:
- adds a `.gitignore` file.
- adds a `COPYRIGHT` file to the repo for clarity on what the contents are licensed under.
- import the `.clang-format` file from FreeBSD.
- adds a `pre-commit` config.
- adds/updates copyrights for the project.
- removes `$Id` from files.
- removes trailing whitespace from files.